### PR TITLE
Handle timeout fallbacks in process handler

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,2 @@
+"""Application package for the real estate voice bot."""
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,6 @@ pypdf
 # Speech (optional – not used in Twilio mode but won’t hurt)
 SpeechRecognition
 pyttsx3
+
+# Testing
+pytest

--- a/tests/test_process_timeout.py
+++ b/tests/test_process_timeout.py
@@ -1,0 +1,49 @@
+import logging
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.main import FALLBACK_REPLY, _sessions, app
+from app.voice2 import OptimizedVoiceAssistant
+
+
+@pytest.fixture(autouse=True)
+def clear_sessions():
+    _sessions.clear()
+    yield
+    _sessions.clear()
+
+
+def test_process_timeout_uses_fallback(monkeypatch, caplog):
+    client = TestClient(app)
+    call_sid = "CA123TIMEOUT"
+
+    def slow_generate(self, user_input, intent):
+        time.sleep(5)
+        return "This should not be used"
+
+    monkeypatch.setattr(
+        OptimizedVoiceAssistant, "generate_fast_response", slow_generate
+    )
+    caplog.set_level(logging.WARNING)
+
+    client.post("/voice", data={"CallSid": call_sid, "From": "+100", "To": "+200"})
+
+    response = client.post(
+        "/process",
+        data={"CallSid": call_sid, "SpeechResult": "Tell me about ROI"},
+    )
+
+    assert response.status_code == 200
+    body = response.text
+    assert FALLBACK_REPLY in body
+    assert "<Gather" in body
+    assert call_sid in "".join(caplog.messages)
+    assert call_sid in _sessions


### PR DESCRIPTION
## Summary
- gracefully handle timeout errors in the /process webhook by logging them and replying with a canned prompt that keeps the session alive
- ensure the fallback path continues the gather flow while leaving the session active
- add pytest dependency and a unit test that simulates the timeout scenario for generate_fast_response

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cff4c81b00832ab1a2c50c9f6f453b